### PR TITLE
Resolved bento warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ WORKDIR /servo
 
 # replaced 'latest stable' with fixed version of kubectl, to support k8s 1.8.x
 #    ver=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) ; 
-
+# hadolint ignore=DL3013
 RUN set -e ; apt-get update ; apt-get dist-upgrade -y ; apt-get install --no-install-recommends -y curl ; \
     ver=v1.10.3 ; \
     curl -LO https://storage.googleapis.com/kubernetes-release/release/$ver/bin/linux/amd64/kubectl ; \
     chmod +x ./kubectl ; mv ./kubectl /usr/local/bin/kubectl ; \
-    pip3 install requests PyYAML
+    pip3 install requests PyYAML ; \
+    apt-get clean ; \
+    rm -rf /var/lib/apt/lists/*
 
 ADD servo-m w2.py /servo/
 

--- a/mon/Dockerfile
+++ b/mon/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.6-alpine
 
 WORKDIR /servo
 
-RUN set -e ; apk update ; apk upgrade ; \
-    pip3 install requests
+# hadolint ignore=DL3013
+RUN set -e ; pip3 install requests
 
 ADD pod-mon.py /servo/
 

--- a/mon/pod-mon.py
+++ b/mon/pod-mon.py
@@ -47,7 +47,7 @@ def term_handler(n,frame):
         # use 'with' to ensure session is CLOSED before we terminate this process
         with requests.Session() as s:
             s.post(URI, json = { "id": ID, "stats": data }, timeout = POST_TIMEOUT)
-    except Exception:
+    except Exception: # nosec (ignore failure)
         pass
     sys.exit()
 

--- a/noterm/Dockerfile
+++ b/noterm/Dockerfile
@@ -1,3 +1,4 @@
+# hadolint ignore=DL3007
 FROM busybox:latest
 
 ENTRYPOINT [ "/bin/sh", "-c", "trap '' TERM ; read r </dev/ptmx ;" ]

--- a/w2.py
+++ b/w2.py
@@ -70,6 +70,9 @@ except Exception:
 class ApiError(Exception):
     pass
 
+class ConfigError(Exception):
+    pass
+
 class UserError(Exception): # raised on invalid input data from remote OCO
     pass
 # ===
@@ -115,7 +118,7 @@ def update1(obj, path1, path2, val):
         dprint("ERR: no {} in {}".format(path1, repr(obj)))
         return # FIXME raise H*ll
     p2 = path2.split("/")
-    if p2[0] == "": p2 = p1[1:] # remove leading /
+    if p2[0] == "": p2 = p2[1:] # remove leading /
     left = p2[0:-1]
     right = p2[-1]
     o = val
@@ -475,13 +478,13 @@ def run_watch(v, p_line):
             break
         for h in r:
             if h is proc.stderr:
-                l = h.read(4096)
+                l = h.read(4096) # noqa: E741 (l as in line)
                 if not l:
                     eof_stderr = True
                     continue
                 stderr.append(l)
             else: # h is proc.stdout
-                l = h.readline()
+                l = h.readline() # noqa: E741 (l as in line)
                 if not l:
                     eof_stdout = True
                     continue
@@ -498,7 +501,8 @@ def run_watch(v, p_line):
                 v = p_line(stdout)
                 if v is None: return 1, v # failure - return to trigger a new 'get' of all pods
         if w:
-            l = min(getattr(select,'PIPE_BUF',512), len(stdin)) # write with select.PIPE_BUF bytes or less should not block
+            # write with select.PIPE_BUF bytes or less should not block
+            l = min(getattr(select,'PIPE_BUF',512), len(stdin)) # noqa: E741 (l as in line)
             if not l: # done sending stdin
                 proc.stdin.close()
                 wi = []


### PR DESCRIPTION
Bento Output:

```
hadolint DL3009 https://github.com/hadolint/hadolint/wiki/DL3009
     > Dockerfile:8
     ╷
    8│   RUN set -e ; apt-get update ; apt-get dist-upgrade -y ; apt-get install --no-install-recommends -y curl ; \
     ╵
     = Delete the apt-get lists after installing something

hadolint DL3013 https://github.com/hadolint/hadolint/wiki/DL3013
     > Dockerfile:8
     ╷
    8│   RUN set -e ; apt-get update ; apt-get dist-upgrade -y ; apt-get install --no-install-recommends -y curl ; \
     ╵
     = Pin versions in pip. Instead of `pip install <package>` use `pip install
       <package>==<version>`

hadolint DL3017 https://github.com/hadolint/hadolint/wiki/DL3017
     > mon/Dockerfile:5
     ╷
    5│   RUN set -e ; apk update ; apk upgrade ; \
     ╵
     = Do not use apk upgrade

hadolint DL3013 https://github.com/hadolint/hadolint/wiki/DL3013
     > mon/Dockerfile:5
     ╷
    5│   RUN set -e ; apk update ; apk upgrade ; \
     ╵
     = Pin versions in pip. Instead of `pip install <package>` use `pip install
       <package>==<version>`

bandit try-except-pass https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html
     > mon/pod-mon.py:50
     ╷
   50│   except Exception:
     ╵
     = Try, Except, Pass detected.

hadolint DL3007 https://github.com/hadolint/hadolint/wiki/DL3007
     > noterm/Dockerfile:1
     ╷
    1│   FROM busybox:latest
     ╵
     = Using latest is prone to errors if the image will ever update. Pin the
       version explicitly to a release tag

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > w2.py:118
     ╷
  118│   if p2[0] == "": p2 = p1[1:] # remove leading /
     ╵
     = undefined name 'p1'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > w2.py:478
     ╷
  478│   l = h.read(4096)
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > w2.py:484
     ╷
  484│   l = h.readline()
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > w2.py:501
     ╷
  501│   l = min(getattr(select,'PIPE_BUF',512), len(stdin)) # write with select.PIPE_BUF bytes or less should not block
     ╵
     = ambiguous variable name 'l'

flake8 undefined-name https://lintlyci.github.io/Flake8Rules/rules/F821.html
     > w2.py:610
     ╷
  610│   raise ConfigError("invalid value found in environment {}={}, it was expected to be numeric".format(ev["name"],ev["value"]))
     ╵
     = undefined name 'ConfigError'
```